### PR TITLE
Add new map wr endpoint

### DIFF
--- a/lib/__tests__/schema.test.js
+++ b/lib/__tests__/schema.test.js
@@ -2,7 +2,7 @@ import "regenerator-runtime/runtime";
 import { graphql } from "graphql";
 import axios from "axios";
 import { schema } from "../schema";
-import { activity, mapsByName } from "../tempus";
+import { activity, mapsByName, wrsByMapName } from "../tempus";
 
 jest.mock("axios");
 
@@ -23,6 +23,7 @@ beforeEach(() => {
   });
   activity.clearCache();
   mapsByName.clearCache();
+  wrsByMapName.clearCache();
   requestStubs = {};
 });
 
@@ -221,6 +222,7 @@ describe("map", () => {
     expect(axios.get).toHaveBeenCalledWith(
       `${BASE_URL}maps/name/jump_rush/wrs`
     );
+    console.log(JSON.stringify(r, null, 2));
     expect(r).toEqual({
       data: {
         map: {

--- a/lib/__tests__/schema.test.js
+++ b/lib/__tests__/schema.test.js
@@ -196,6 +196,7 @@ describe("map", () => {
     stubRequest("maps/name/jump_rush/wrs", {
       soldier: {
         wr: {
+          duration: 5.0,
           zone_id: 1,
           splits: [
             {
@@ -205,6 +206,9 @@ describe("map", () => {
               compared_duration: 2.0,
             },
           ],
+        },
+        rank2: {
+          duration: 10.0,
         },
       },
     });
@@ -222,7 +226,6 @@ describe("map", () => {
     expect(axios.get).toHaveBeenCalledWith(
       `${BASE_URL}maps/name/jump_rush/wrs`
     );
-    console.log(JSON.stringify(r, null, 2));
     expect(r).toEqual({
       data: {
         map: {
@@ -241,6 +244,12 @@ describe("map", () => {
                 zoneindex: 1,
                 duration: 1.0,
                 comparedDuration: 2.0,
+              },
+              {
+                type: "map",
+                zoneindex: 1,
+                duration: 5.0,
+                comparedDuration: 10.0,
               },
             ],
           },

--- a/lib/__tests__/schema.test.js
+++ b/lib/__tests__/schema.test.js
@@ -190,4 +190,60 @@ describe("map", () => {
 
   test.skip("requests map runs", async () => {});
   test.skip("requests records", async () => {});
+
+  test("request map wrs", async () => {
+    stubRequest("maps/name/jump_rush/wrs", {
+      soldier: {
+        wr: {
+          zone_id: 1,
+          splits: [
+            {
+              type: "checkpoint",
+              zoneindex: 1,
+              duration: 1.0,
+              compared_duration: 2.0,
+            },
+          ],
+        },
+      },
+    });
+    stubRequest("maps/name/jump_rush/fullOverview2", {
+      map_info: {
+        name: "jump_rush",
+        id: 111,
+      },
+    });
+
+    const r = await request(
+      '{ map(name: "jump_rush") { wr(class: SOLDIER) { zone { id type map { name id } } splits { type zoneindex duration comparedDuration } } }}'
+    );
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `${BASE_URL}maps/name/jump_rush/wrs`
+    );
+    expect(r).toEqual({
+      data: {
+        map: {
+          wr: {
+            zone: {
+              id: 1,
+              type: "map",
+              map: {
+                name: "jump_rush",
+                id: "111",
+              },
+            },
+            splits: [
+              {
+                type: "checkpoint",
+                zoneindex: 1,
+                duration: 1.0,
+                comparedDuration: 2.0,
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
 });

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -6,6 +6,8 @@ import {
   recordListByMapId,
   playerRecordByMapName,
   playerRecordByMapId,
+  wrsByMapName,
+  wrsByMapId,
 } from "../tempus";
 import Record from "./record";
 import Player from "./player";
@@ -111,6 +113,39 @@ class Map extends BaseModel {
           name: r.result.demo_server_name,
         },
       },
+    });
+  }
+
+  async wr(args) {
+    let rs = null;
+    if (this.attrs.name) {
+      rs = await wrsByMapName.load(this.attrs.name);
+    } else {
+      rs = await wrsByMapId.load(this.attrs.id);
+    }
+    if (args.class === "soldier") {
+      if (!rs.soldier) return null;
+      return new Record({
+        ...rs.soldier.wr,
+        zone_info: {
+          id: rs.soldier.wr.zone_id,
+          map_id: this.attrs.id,
+          type: "map",
+          zoneindex: 1
+        },
+        map: this
+      });
+    }
+    if (!rs.demoman) return null;
+    return new Record({
+      ...rs.demoman.wr,
+      zone_info: {
+        id: rs.demoman.wr.zone_id,
+        map_id: this.attrs.id,
+        type: "map",
+        zoneindex: 1
+      },
+      map: this
     });
   }
 }

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -132,9 +132,9 @@ class Map extends BaseModel {
           map_id: this.attrs.id,
           map_name: this.attrs.name,
           type: "map",
-          zoneindex: 1
+          zoneindex: 1,
         },
-        map: this
+        map: this,
       });
     }
     if (!rs.demoman) return null;
@@ -145,9 +145,9 @@ class Map extends BaseModel {
         map_id: this.attrs.id,
         map_name: this.attrs.name,
         type: "map",
-        zoneindex: 1
+        zoneindex: 1,
       },
-      map: this
+      map: this,
     });
   }
 }

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -130,6 +130,7 @@ class Map extends BaseModel {
         zone_info: {
           id: rs.soldier.wr.zone_id,
           map_id: this.attrs.id,
+          map_name: this.attrs.name,
           type: "map",
           zoneindex: 1
         },
@@ -142,6 +143,7 @@ class Map extends BaseModel {
       zone_info: {
         id: rs.demoman.wr.zone_id,
         map_id: this.attrs.id,
+        map_name: this.attrs.name,
         type: "map",
         zoneindex: 1
       },

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -123,25 +123,21 @@ class Map extends BaseModel {
     } else {
       rs = await wrsByMapId.load(this.attrs.id);
     }
+    let className = "demoman";
     if (args.class === "soldier") {
-      if (!rs.soldier) return null;
-      return new Record({
-        ...rs.soldier.wr,
-        zone_info: {
-          id: rs.soldier.wr.zone_id,
-          map_id: this.attrs.id,
-          map_name: this.attrs.name,
-          type: "map",
-          zoneindex: 1,
-        },
-        map: this,
-      });
+      className = "soldier";
     }
-    if (!rs.demoman) return null;
+    if (!rs[className]) return null;
+    rs[className].wr.splits.push({
+      type: "map",
+      zoneindex: 1,
+      duration: rs[className].wr.duration,
+      compared_duration: rs[className].rank2 && rs[className].rank2.duration,
+    });
     return new Record({
-      ...rs.demoman.wr,
+      ...rs[className].wr,
       zone_info: {
-        id: rs.demoman.wr.zone_id,
+        id: rs[className].wr.zone_id,
         map_id: this.attrs.id,
         map_name: this.attrs.name,
         type: "map",

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -124,7 +124,8 @@ class Map extends BaseModel {
       rs = await wrsByMapId.load(this.attrs.id);
     }
     if (!rs[args.class]) return null;
-    rs[args.class].wr.splits.push({
+    const splits = JSON.parse(JSON.stringify(rs[args.class].wr.splits));
+    splits.push({
       type: "map",
       zoneindex: 1,
       duration: rs[args.class].wr.duration,
@@ -140,6 +141,7 @@ class Map extends BaseModel {
         zoneindex: 1,
       },
       map: this,
+      splits,
     });
   }
 }

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -123,21 +123,17 @@ class Map extends BaseModel {
     } else {
       rs = await wrsByMapId.load(this.attrs.id);
     }
-    let className = "demoman";
-    if (args.class === "soldier") {
-      className = "soldier";
-    }
-    if (!rs[className]) return null;
-    rs[className].wr.splits.push({
+    if (!rs[args.class]) return null;
+    rs[args.class].wr.splits.push({
       type: "map",
       zoneindex: 1,
-      duration: rs[className].wr.duration,
-      compared_duration: rs[className].rank2 && rs[className].rank2.duration,
+      duration: rs[args.class].wr.duration,
+      compared_duration: rs[args.class].rank2 && rs[args.class].rank2.duration,
     });
     return new Record({
-      ...rs[className].wr,
+      ...rs[args.class].wr,
       zone_info: {
-        id: rs[className].wr.zone_id,
+        id: rs[args.class].wr.zone_id,
         map_id: this.attrs.id,
         map_name: this.attrs.name,
         type: "map",

--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -5,7 +5,7 @@ import Demo from "./demo";
 import Zone from "./zone";
 import Server from "./server";
 import Split from "./split";
-import { recordsById } from "../tempus";
+import { recordsById, wrsByMapId, wrsByMapName } from "../tempus";
 
 class Record extends BaseModel {
   fetchRecord() {
@@ -79,11 +79,31 @@ class Record extends BaseModel {
     );
   }
 
-  splits() {
-    if (this.attrs.splits) {
-      return this.attrs.splits.map((split) => new Split(split));
+  async splits() {
+    if (this.rank > 1) return [];
+
+    let splits =
+      this.attrs.splits || (await this.access("splits", (r) => r.splits));
+
+    if (!splits) {
+      let rs = null;
+      if (this.attrs.map.attrs.name) {
+        rs = await wrsByMapName.load(this.attrs.map.attrs.name);
+      } else {
+        rs = await wrsByMapId.load(this.attrs.map.attrs.id);
+      }
+      if (!rs[this.attrs.class]) return [];
+      splits = JSON.parse(JSON.stringify(rs[this.attrs.class].wr.splits));
+      splits.push({
+        type: "map",
+        zoneindex: 1,
+        duration: rs[this.attrs.class].wr.duration,
+        compared_duration:
+          rs[this.attrs.class].rank2 && rs[this.attrs.class].rank2.duration,
+      });
     }
-    return [];
+
+    return splits.map((split) => new Split(split));
   }
 }
 

--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -4,6 +4,7 @@ import Map from "./map";
 import Demo from "./demo";
 import Zone from "./zone";
 import Server from "./server";
+import Split from "./split";
 import { recordsById } from "../tempus";
 
 class Record extends BaseModel {
@@ -76,6 +77,13 @@ class Record extends BaseModel {
       "server",
       (r) => new Server({ id: r.record_info.server_id })
     );
+  }
+
+  splits() {
+    if (this.attrs.splits) {
+      return this.attrs.splits.map(split => new Split(split));
+    }
+    return [];
   }
 }
 

--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -81,7 +81,7 @@ class Record extends BaseModel {
 
   splits() {
     if (this.attrs.splits) {
-      return this.attrs.splits.map(split => new Split(split));
+      return this.attrs.splits.map((split) => new Split(split));
     }
     return [];
   }

--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -82,24 +82,29 @@ class Record extends BaseModel {
   async splits() {
     if (this.rank > 1) return [];
 
-    let splits =
-      this.attrs.splits || (await this.access("splits", (r) => r.splits));
+    let { splits } = this.attrs;
 
     if (!splits) {
       let rs = null;
-      if (this.attrs.map.attrs.name) {
-        rs = await wrsByMapName.load(this.attrs.map.attrs.name);
+      if (this.attrs.map_info.name || this.attrs.map.attrs.name) {
+        rs = await wrsByMapName.load(
+          this.attrs.map_info.name || this.attrs.map.attrs.name
+        );
       } else {
-        rs = await wrsByMapId.load(this.attrs.map.attrs.id);
+        rs = await wrsByMapId.load(
+          this.attrs.map_info.id || this.attrs.map.attrs.id
+        );
       }
-      if (!rs[this.attrs.class]) return [];
-      splits = JSON.parse(JSON.stringify(rs[this.attrs.class].wr.splits));
+      const cls = [3, "soldier"].includes(this.attrs.class)
+        ? "soldier"
+        : "demoman";
+      if (!rs[cls]) return [];
+      splits = JSON.parse(JSON.stringify(rs[cls].wr.splits));
       splits.push({
         type: "map",
         zoneindex: 1,
-        duration: rs[this.attrs.class].wr.duration,
-        compared_duration:
-          rs[this.attrs.class].rank2 && rs[this.attrs.class].rank2.duration,
+        duration: rs[cls].wr.duration,
+        compared_duration: rs[cls].rank2 && rs[cls].rank2.duration,
       });
     }
 

--- a/lib/models/split.js
+++ b/lib/models/split.js
@@ -1,0 +1,25 @@
+import BaseModel from "./base_model";
+
+class Split extends BaseModel {
+  type() {
+    return this.attrs.type;
+  }
+
+  zoneindex() {
+    return this.attrs.zoneindex;
+  }
+
+  customName() {
+    return this.attrs.custom_name;
+  }
+
+  duration() {
+    return this.attrs.duration;
+  }
+
+  comparedDuration() {
+    return this.attrs.compared_duration;
+  }
+}
+
+export default Split;

--- a/lib/models/zone.js
+++ b/lib/models/zone.js
@@ -7,6 +7,10 @@ class Zone extends BaseModel {
   }
 
   map() {
+    if (this.attrs.map_name) {
+      return new Map({ name: this.attrs.map_name });
+    }
+
     return new Map({ id: this.attrs.map_id });
   }
 

--- a/lib/tempus.js
+++ b/lib/tempus.js
@@ -86,6 +86,14 @@ const serversById = {
     return servers.find((s) => s.id === id);
   },
 };
+const wrsByMapName = new CachedByKeyResource(
+  (name) => fetchResponseByURL(`maps/name/${name}/wrs`),
+  { timeout: 120 }
+);
+const wrsByMapId = new CachedByKeyResource(
+  (id) => fetchResponseByURL(`maps/id/${id}/wrs`),
+  { timeout: 120 }
+);
 
 export {
   mapsById,
@@ -104,4 +112,6 @@ export {
   allMaps,
   activity,
   rankingsByType,
+  wrsByMapName,
+  wrsByMapId,
 };

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -98,7 +98,7 @@ export default new GraphQLObjectType({
       type: RecordType,
       args: {
         class: { type: new GraphQLNonNull(ClassTypeEnum) },
-      }
+      },
     },
   }),
 });

--- a/lib/types/map.js
+++ b/lib/types/map.js
@@ -94,5 +94,11 @@ export default new GraphQLObjectType({
         class: { type: new GraphQLNonNull(ClassTypeEnum) },
       },
     },
+    wr: {
+      type: RecordType,
+      args: {
+        class: { type: new GraphQLNonNull(ClassTypeEnum) },
+      }
+    },
   }),
 });

--- a/lib/types/record.js
+++ b/lib/types/record.js
@@ -31,6 +31,8 @@ export default new GraphQLObjectType({
     demoStartTick: { type: GraphQLInt },
     demoEndTick: { type: GraphQLInt },
     server: { type: new GraphQLNonNull(ServerType) },
-    splits: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(SplitType))) }
+    splits: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(SplitType))),
+    },
   }),
 });

--- a/lib/types/record.js
+++ b/lib/types/record.js
@@ -3,6 +3,7 @@ import {
   GraphQLFloat,
   GraphQLInt,
   GraphQLNonNull,
+  GraphQLList,
 } from "graphql";
 import PlayerType from "./player";
 import MapType from "./map";
@@ -11,6 +12,7 @@ import DemoType from "./demo";
 import ServerType from "./server";
 import ZoneType from "./zone";
 import ClassTypeEnum from "./class_type_enum";
+import SplitType from "./split";
 
 export default new GraphQLObjectType({
   name: "Record",
@@ -29,5 +31,6 @@ export default new GraphQLObjectType({
     demoStartTick: { type: GraphQLInt },
     demoEndTick: { type: GraphQLInt },
     server: { type: new GraphQLNonNull(ServerType) },
+    splits: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(SplitType))) }
   }),
 });

--- a/lib/types/split.js
+++ b/lib/types/split.js
@@ -1,0 +1,19 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLFloat
+} from "graphql";
+
+export default new GraphQLObjectType({
+  name: "Split",
+
+  fields: () => ({
+    type: { type: new GraphQLNonNull(GraphQLString) },
+    zoneindex: { type: new GraphQLNonNull(GraphQLInt) },
+    customName: { type: GraphQLString },
+    duration: { type: GraphQLFloat },
+    comparedDuration: { type: GraphQLFloat },
+  }),
+});

--- a/lib/types/split.js
+++ b/lib/types/split.js
@@ -3,7 +3,7 @@ import {
   GraphQLString,
   GraphQLInt,
   GraphQLNonNull,
-  GraphQLFloat
+  GraphQLFloat,
 } from "graphql";
 
 export default new GraphQLObjectType({

--- a/schema.graphql
+++ b/schema.graphql
@@ -21,6 +21,7 @@ type Map {
   zones: Zones!
   records(zoneType: ZoneType, zoneId: Int, start: Int, limit: Int, class: Class!): [Record!]!
   record(zoneType: ZoneType, zoneId: Int, playerId: Int!, class: Class!): Record
+  wr(class: Class!): Record
 }
 
 type Author {
@@ -89,6 +90,7 @@ type Record {
   demoStartTick: Int
   demoEndTick: Int
   server: Server!
+  splits: [Split!]!
 }
 
 type Tiers {
@@ -141,6 +143,14 @@ type Server {
 enum Class {
   SOLDIER
   DEMOMAN
+}
+
+type Split {
+  type: String!
+  zoneindex: Int!
+  customName: String
+  duration: Float
+  comparedDuration: Float
 }
 
 enum ZoneType {


### PR DESCRIPTION
Adds functionality for the new `maps/name/<map_name>/wrs` endpoint.  

Sample query and response:  
```graphql
{
  map(name: "jump_elephant_a2") {
    wr(class: SOLDIER) {
      splits {
        type
        zoneindex
        customName
        duration
        comparedDuration
      }
    }
  }
}
```
```json
{
  "data": {
    "map": {
      "wr": {
        "splits": [
          {
            "type": "checkpoint",
            "zoneindex": 1,
            "customName": null,
            "duration": 8.729441165924072,
            "comparedDuration": 8.96986174583435
          },
          {
            "type": "checkpoint",
            "zoneindex": 2,
            "customName": null,
            "duration": 29.00977063179016,
            "comparedDuration": 32.444780349731445
          }
        ]
      }
    }
  }
}
```

The only additional data in this resource compared to `maps/name/<map_name>/zones/typeindex/map/1/records/list`  is the time splits for the world record; it might be worth abstracting this into the existing `records` query if possible.