### PR TITLE
Rework to inject dependencies via model context

### DIFF
--- a/lib/__tests__/schema.test.js
+++ b/lib/__tests__/schema.test.js
@@ -1,13 +1,16 @@
 import "regenerator-runtime/runtime";
 import { graphql } from "graphql";
 import axios from "axios";
-import { schema } from "../schema";
-import { activity, mapsByName, wrsByMapName } from "../tempus";
+import { newTempusSchema } from "../schema";
+import { newCachedTempusFetcher } from "../tempus";
+import fetchResponseByURL from "../utils/fetch_response_by_url";
 
 jest.mock("axios");
 
+const tempus = newCachedTempusFetcher(fetchResponseByURL);
+
 async function request(query) {
-  return graphql(schema, query);
+  return graphql(newTempusSchema(tempus), query);
 }
 
 let requestStubs = {};
@@ -21,9 +24,8 @@ beforeEach(() => {
 
     return Promise.resolve(returnValue);
   });
-  activity.clearCache();
-  mapsByName.clearCache();
-  wrsByMapName.clearCache();
+
+  tempus.clearCache();
   requestStubs = {};
 });
 

--- a/lib/models/activity.js
+++ b/lib/models/activity.js
@@ -3,14 +3,14 @@ import Record from "./record";
 
 class Activity extends BaseModel {
   fetchRecord() {
-    return this._context.tempus.activity.load();
+    return this.context.tempus.activity.load();
   }
 
   accessRecords(type, extraAttrs, args) {
     return this.access(null, (r) => {
       let records = r[type].map(
         (rec) =>
-          new Record(this._context, {
+          new Record(this.context, {
             ...rec,
             ...rec.record_info,
             ...extraAttrs,

--- a/lib/models/activity.js
+++ b/lib/models/activity.js
@@ -1,16 +1,20 @@
 import BaseModel from "./base_model";
-import { activity } from "../tempus";
 import Record from "./record";
 
 class Activity extends BaseModel {
   fetchRecord() {
-    return activity.load();
+    return this._context.tempus.activity.load();
   }
 
   accessRecords(type, extraAttrs, args) {
     return this.access(null, (r) => {
       let records = r[type].map(
-        (rec) => new Record({ ...rec, ...rec.record_info, ...extraAttrs })
+        (rec) =>
+          new Record(this._context, {
+            ...rec,
+            ...rec.record_info,
+            ...extraAttrs,
+          })
       );
 
       if (args.start) records = records.slice(args.start - 1);

--- a/lib/models/base_model.js
+++ b/lib/models/base_model.js
@@ -2,7 +2,7 @@
 
 class BaseModel {
   constructor(context, attrs) {
-    this._context = context;
+    this.context = context;
     this.attrs = attrs;
   }
 

--- a/lib/models/base_model.js
+++ b/lib/models/base_model.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 
 class BaseModel {
-  constructor(attrs) {
+  constructor(context, attrs) {
+    this._context = context;
     this.attrs = attrs;
   }
 

--- a/lib/models/demo.js
+++ b/lib/models/demo.js
@@ -5,7 +5,7 @@ import Server from "./server";
 
 class Demo extends BaseModel {
   fetchRecord() {
-    return this._context.tempus.demosById.load(this.attrs.id);
+    return this.context.tempus.demosById.load(this.attrs.id);
   }
 
   id() {
@@ -14,11 +14,11 @@ class Demo extends BaseModel {
 
   map() {
     if (this.attrs.mapname)
-      return new Map(this._context, { name: this.attrs.mapname });
+      return new Map(this.context, { name: this.attrs.mapname });
 
     return this.access(
       "map",
-      (r) => new Map(this._context, { name: r.demo_info.mapname })
+      (r) => new Map(this.context, { name: r.demo_info.mapname })
     );
   }
 
@@ -53,7 +53,7 @@ class Demo extends BaseModel {
   uploader() {
     if ("uploader_id" in this.attrs) {
       if (this.attrs.uploader_id)
-        return new Player(this._context, { name: this.attrs.uploader_id });
+        return new Player(this.context, { name: this.attrs.uploader_id });
 
       return null;
     }
@@ -62,17 +62,17 @@ class Demo extends BaseModel {
       "uploader",
       (r) =>
         r.demo_info.uploader_id &&
-        new Player(this._context, { id: r.demo_info.uploader_id })
+        new Player(this.context, { id: r.demo_info.uploader_id })
     );
   }
 
   server() {
     if (this.attrs.server_info)
-      return new Server(this._context, this.attrs.server_info);
+      return new Server(this.context, this.attrs.server_info);
 
     return this.access(
       "server",
-      (r) => new Server(this._context, r.server_info)
+      (r) => new Server(this.context, r.server_info)
     );
   }
 }

--- a/lib/models/demo.js
+++ b/lib/models/demo.js
@@ -1,12 +1,11 @@
 import BaseModel from "./base_model";
-import { demosById } from "../tempus";
 import Player from "./player";
 import Map from "./map";
 import Server from "./server";
 
 class Demo extends BaseModel {
   fetchRecord() {
-    return demosById.load(this.attrs.id);
+    return this._context.tempus.demosById.load(this.attrs.id);
   }
 
   id() {
@@ -14,9 +13,13 @@ class Demo extends BaseModel {
   }
 
   map() {
-    if (this.attrs.mapname) return new Map({ name: this.attrs.mapname });
+    if (this.attrs.mapname)
+      return new Map(this._context, { name: this.attrs.mapname });
 
-    return this.access("map", (r) => new Map({ name: r.demo_info.mapname }));
+    return this.access(
+      "map",
+      (r) => new Map(this._context, { name: r.demo_info.mapname })
+    );
   }
 
   filename() {
@@ -50,7 +53,7 @@ class Demo extends BaseModel {
   uploader() {
     if ("uploader_id" in this.attrs) {
       if (this.attrs.uploader_id)
-        return new Player({ name: this.attrs.uploader_id });
+        return new Player(this._context, { name: this.attrs.uploader_id });
 
       return null;
     }
@@ -58,14 +61,19 @@ class Demo extends BaseModel {
     return this.access(
       "uploader",
       (r) =>
-        r.demo_info.uploader_id && new Player({ id: r.demo_info.uploader_id })
+        r.demo_info.uploader_id &&
+        new Player(this._context, { id: r.demo_info.uploader_id })
     );
   }
 
   server() {
-    if (this.attrs.server_info) return new Server(this.attrs.server_info);
+    if (this.attrs.server_info)
+      return new Server(this._context, this.attrs.server_info);
 
-    return this.access("server", (r) => new Server(r.server_info));
+    return this.access(
+      "server",
+      (r) => new Server(this._context, r.server_info)
+    );
   }
 }
 

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -1,14 +1,4 @@
 import BaseModel from "./base_model";
-import {
-  mapsByName,
-  mapsById,
-  recordListByMapName,
-  recordListByMapId,
-  playerRecordByMapName,
-  playerRecordByMapId,
-  wrsByMapName,
-  wrsByMapId,
-} from "../tempus";
 import Record from "./record";
 import Player from "./player";
 import Zone from "./zone";
@@ -16,9 +6,9 @@ import Zone from "./zone";
 class Map extends BaseModel {
   fetchRecord() {
     if (this.attrs.name) {
-      return mapsByName.load(this.attrs.name);
+      return this._context.tempus.mapsByName.load(this.attrs.name);
     }
-    return mapsById.load(this.attrs.id);
+    return this._context.tempus.mapsById.load(this.attrs.id);
   }
 
   id() {
@@ -35,7 +25,9 @@ class Map extends BaseModel {
         if (author.player_info) {
           return {
             ...author,
-            player: author.player_info && new Player(author.player_info),
+            player:
+              author.player_info &&
+              new Player(this._context, author.player_info),
           };
         }
         return author;
@@ -54,16 +46,32 @@ class Map extends BaseModel {
   zones() {
     return this.access("zones", (r) => {
       return {
-        bonus: (r.zones.bonus || []).map((zone) => new Zone(zone)),
-        bonusEnd: (r.zones.bonus_end || []).map((zone) => new Zone(zone)),
-        checkpoint: (r.zones.checkpoint || []).map((zone) => new Zone(zone)),
-        course: (r.zones.course || []).map((zone) => new Zone(zone)),
-        courseEnd: (r.zones.course_end || []).map((zone) => new Zone(zone)),
-        linear: (r.zones.linear || []).map((zone) => new Zone(zone)),
-        map: (r.zones.map || []).map((zone) => new Zone(zone)),
-        mapEnd: (r.zones.map_end || []).map((zone) => new Zone(zone)),
-        misc: (r.zones.misc || []).map((zone) => new Zone(zone)),
-        trick: (r.zones.trick || []).map((zone) => new Zone(zone)),
+        bonus: (r.zones.bonus || []).map(
+          (zone) => new Zone(this._context, zone)
+        ),
+        bonusEnd: (r.zones.bonus_end || []).map(
+          (zone) => new Zone(this._context, zone)
+        ),
+        checkpoint: (r.zones.checkpoint || []).map(
+          (zone) => new Zone(this._context, zone)
+        ),
+        course: (r.zones.course || []).map(
+          (zone) => new Zone(this._context, zone)
+        ),
+        courseEnd: (r.zones.course_end || []).map(
+          (zone) => new Zone(this._context, zone)
+        ),
+        linear: (r.zones.linear || []).map(
+          (zone) => new Zone(this._context, zone)
+        ),
+        map: (r.zones.map || []).map((zone) => new Zone(this._context, zone)),
+        mapEnd: (r.zones.map_end || []).map(
+          (zone) => new Zone(this._context, zone)
+        ),
+        misc: (r.zones.misc || []).map((zone) => new Zone(this._context, zone)),
+        trick: (r.zones.trick || []).map(
+          (zone) => new Zone(this._context, zone)
+        ),
       };
     });
   }
@@ -71,38 +79,46 @@ class Map extends BaseModel {
   async records(args) {
     let rs = null;
     if (this.attrs.name) {
-      rs = await recordListByMapName.load({
+      rs = await this._context.tempus.recordListByMapName.load({
         mapName: this.attrs.name,
         ...args,
       });
     } else {
-      rs = await recordListByMapId.load({ mapId: this.attrs.id, ...args });
+      rs = await this._context.tempus.recordListByMapId.load({
+        mapId: this.attrs.id,
+        ...args,
+      });
     }
-    const zone = new Zone({ ...rs.zone_info, map: this });
+    const zone = new Zone(this._context, { ...rs.zone_info, map: this });
     if (args.class === "soldier") {
       return rs.results.soldier.map(
-        (record) => new Record({ ...record, zone, map: this, class: 3 })
+        (record) =>
+          new Record(this._context, { ...record, zone, map: this, class: 3 })
       );
     }
 
     return rs.results.demoman.map(
-      (record) => new Record({ ...record, zone, map: this, class: 4 })
+      (record) =>
+        new Record(this._context, { ...record, zone, map: this, class: 4 })
     );
   }
 
   async record(args) {
     let r = null;
     if (this.attrs.name) {
-      r = await playerRecordByMapName.load({
+      r = await this._context.tempus.playerRecordByMapName.load({
         mapName: this.attrs.name,
         ...args,
       });
     } else {
-      r = await playerRecordByMapId.load({ mapId: this.attrs.id, ...args });
+      r = await this._context.tempus.playerRecordByMapId.load({
+        mapId: this.attrs.id,
+        ...args,
+      });
     }
     if (!r.result) return null;
 
-    return new Record({
+    return new Record(this._context, {
       ...r.result,
       zone_info: r.zone_info,
       player_info: {
@@ -125,9 +141,9 @@ class Map extends BaseModel {
   async wr(args) {
     let rs = null;
     if (this.attrs.name) {
-      rs = await wrsByMapName.load(this.attrs.name);
+      rs = await this._context.tempus.wrsByMapName.load(this.attrs.name);
     } else {
-      rs = await wrsByMapId.load(this.attrs.id);
+      rs = await this._context.tempus.wrsByMapId.load(this.attrs.id);
     }
     if (!rs[args.class]) return null;
     const splits = JSON.parse(JSON.stringify(rs[args.class].wr.splits));
@@ -137,7 +153,7 @@ class Map extends BaseModel {
       duration: rs[args.class].wr.duration,
       compared_duration: rs[args.class].rank2 && rs[args.class].rank2.duration,
     });
-    return new Record({
+    return new Record(this._context, {
       ...rs[args.class].wr,
       zone_info: {
         id: rs[args.class].wr.zone_id,

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -6,9 +6,9 @@ import Zone from "./zone";
 class Map extends BaseModel {
   fetchRecord() {
     if (this.attrs.name) {
-      return this._context.tempus.mapsByName.load(this.attrs.name);
+      return this.context.tempus.mapsByName.load(this.attrs.name);
     }
-    return this._context.tempus.mapsById.load(this.attrs.id);
+    return this.context.tempus.mapsById.load(this.attrs.id);
   }
 
   id() {
@@ -27,7 +27,7 @@ class Map extends BaseModel {
             ...author,
             player:
               author.player_info &&
-              new Player(this._context, author.player_info),
+              new Player(this.context, author.player_info),
           };
         }
         return author;
@@ -47,30 +47,30 @@ class Map extends BaseModel {
     return this.access("zones", (r) => {
       return {
         bonus: (r.zones.bonus || []).map(
-          (zone) => new Zone(this._context, zone)
+          (zone) => new Zone(this.context, zone)
         ),
         bonusEnd: (r.zones.bonus_end || []).map(
-          (zone) => new Zone(this._context, zone)
+          (zone) => new Zone(this.context, zone)
         ),
         checkpoint: (r.zones.checkpoint || []).map(
-          (zone) => new Zone(this._context, zone)
+          (zone) => new Zone(this.context, zone)
         ),
         course: (r.zones.course || []).map(
-          (zone) => new Zone(this._context, zone)
+          (zone) => new Zone(this.context, zone)
         ),
         courseEnd: (r.zones.course_end || []).map(
-          (zone) => new Zone(this._context, zone)
+          (zone) => new Zone(this.context, zone)
         ),
         linear: (r.zones.linear || []).map(
-          (zone) => new Zone(this._context, zone)
+          (zone) => new Zone(this.context, zone)
         ),
-        map: (r.zones.map || []).map((zone) => new Zone(this._context, zone)),
+        map: (r.zones.map || []).map((zone) => new Zone(this.context, zone)),
         mapEnd: (r.zones.map_end || []).map(
-          (zone) => new Zone(this._context, zone)
+          (zone) => new Zone(this.context, zone)
         ),
-        misc: (r.zones.misc || []).map((zone) => new Zone(this._context, zone)),
+        misc: (r.zones.misc || []).map((zone) => new Zone(this.context, zone)),
         trick: (r.zones.trick || []).map(
-          (zone) => new Zone(this._context, zone)
+          (zone) => new Zone(this.context, zone)
         ),
       };
     });
@@ -79,46 +79,46 @@ class Map extends BaseModel {
   async records(args) {
     let rs = null;
     if (this.attrs.name) {
-      rs = await this._context.tempus.recordListByMapName.load({
+      rs = await this.context.tempus.recordListByMapName.load({
         mapName: this.attrs.name,
         ...args,
       });
     } else {
-      rs = await this._context.tempus.recordListByMapId.load({
+      rs = await this.context.tempus.recordListByMapId.load({
         mapId: this.attrs.id,
         ...args,
       });
     }
-    const zone = new Zone(this._context, { ...rs.zone_info, map: this });
+    const zone = new Zone(this.context, { ...rs.zone_info, map: this });
     if (args.class === "soldier") {
       return rs.results.soldier.map(
         (record) =>
-          new Record(this._context, { ...record, zone, map: this, class: 3 })
+          new Record(this.context, { ...record, zone, map: this, class: 3 })
       );
     }
 
     return rs.results.demoman.map(
       (record) =>
-        new Record(this._context, { ...record, zone, map: this, class: 4 })
+        new Record(this.context, { ...record, zone, map: this, class: 4 })
     );
   }
 
   async record(args) {
     let r = null;
     if (this.attrs.name) {
-      r = await this._context.tempus.playerRecordByMapName.load({
+      r = await this.context.tempus.playerRecordByMapName.load({
         mapName: this.attrs.name,
         ...args,
       });
     } else {
-      r = await this._context.tempus.playerRecordByMapId.load({
+      r = await this.context.tempus.playerRecordByMapId.load({
         mapId: this.attrs.id,
         ...args,
       });
     }
     if (!r.result) return null;
 
-    return new Record(this._context, {
+    return new Record(this.context, {
       ...r.result,
       zone_info: r.zone_info,
       player_info: {
@@ -141,9 +141,9 @@ class Map extends BaseModel {
   async wr(args) {
     let rs = null;
     if (this.attrs.name) {
-      rs = await this._context.tempus.wrsByMapName.load(this.attrs.name);
+      rs = await this.context.tempus.wrsByMapName.load(this.attrs.name);
     } else {
-      rs = await this._context.tempus.wrsByMapId.load(this.attrs.id);
+      rs = await this.context.tempus.wrsByMapId.load(this.attrs.id);
     }
     if (!rs[args.class]) return null;
     const splits = JSON.parse(JSON.stringify(rs[args.class].wr.splits));
@@ -153,7 +153,7 @@ class Map extends BaseModel {
       duration: rs[args.class].wr.duration,
       compared_duration: rs[args.class].rank2 && rs[args.class].rank2.duration,
     });
-    return new Record(this._context, {
+    return new Record(this.context, {
       ...rs[args.class].wr,
       zone_info: {
         id: rs[args.class].wr.zone_id,

--- a/lib/models/player.js
+++ b/lib/models/player.js
@@ -1,15 +1,10 @@
 import BaseModel from "./base_model";
 import Record from "./record";
-import {
-  playersById,
-  playerRecordByMapId,
-  playerRecordByMapName,
-} from "../tempus";
 import Map from "./map";
 
 class Player extends BaseModel {
   fetchRecord() {
-    return playersById.load(this.attrs.id);
+    return this._context.tempus.playersById.load(this.attrs.id);
   }
 
   id() {
@@ -85,15 +80,21 @@ class Player extends BaseModel {
     let r = null;
     const playerId = await this.id();
     if (args.mapName) {
-      r = await playerRecordByMapName.load({ playerId, ...args });
+      r = await this._context.tempus.playerRecordByMapName.load({
+        playerId,
+        ...args,
+      });
     } else if (args.mapId) {
-      r = await playerRecordByMapId.load({ playerId, ...args });
+      r = await this._context.tempus.playerRecordByMapId.load({
+        playerId,
+        ...args,
+      });
     } else {
       throw new Error('One of "mapId"/"mapName" must be provided.');
     }
     if (!r.result) return null;
 
-    return new Record({
+    return new Record(this._context, {
       ...r.result,
       zone_info: r.zone_info,
       player_info: {
@@ -101,7 +102,7 @@ class Player extends BaseModel {
         name: r.result.name,
         steamid: r.result.steamid,
       },
-      map: new Map({ id: r.zone_info.map_id }),
+      map: new Map(this._context, { id: r.zone_info.map_id }),
       demo_info: {
         id: r.result.demo_id,
         url: r.result.demo_url,

--- a/lib/models/player.js
+++ b/lib/models/player.js
@@ -4,7 +4,7 @@ import Map from "./map";
 
 class Player extends BaseModel {
   fetchRecord() {
-    return this._context.tempus.playersById.load(this.attrs.id);
+    return this.context.tempus.playersById.load(this.attrs.id);
   }
 
   id() {
@@ -80,12 +80,12 @@ class Player extends BaseModel {
     let r = null;
     const playerId = await this.id();
     if (args.mapName) {
-      r = await this._context.tempus.playerRecordByMapName.load({
+      r = await this.context.tempus.playerRecordByMapName.load({
         playerId,
         ...args,
       });
     } else if (args.mapId) {
-      r = await this._context.tempus.playerRecordByMapId.load({
+      r = await this.context.tempus.playerRecordByMapId.load({
         playerId,
         ...args,
       });
@@ -94,7 +94,7 @@ class Player extends BaseModel {
     }
     if (!r.result) return null;
 
-    return new Record(this._context, {
+    return new Record(this.context, {
       ...r.result,
       zone_info: r.zone_info,
       player_info: {
@@ -102,7 +102,7 @@ class Player extends BaseModel {
         name: r.result.name,
         steamid: r.result.steamid,
       },
-      map: new Map(this._context, { id: r.zone_info.map_id }),
+      map: new Map(this.context, { id: r.zone_info.map_id }),
       demo_info: {
         id: r.result.demo_id,
         url: r.result.demo_url,

--- a/lib/models/ranking.js
+++ b/lib/models/ranking.js
@@ -3,7 +3,7 @@ import Player from "./player";
 
 class Ranking extends BaseModel {
   player() {
-    return new Player(this._context, this.attrs);
+    return new Player(this.context, this.attrs);
   }
 
   rank() {

--- a/lib/models/ranking.js
+++ b/lib/models/ranking.js
@@ -3,7 +3,7 @@ import Player from "./player";
 
 class Ranking extends BaseModel {
   player() {
-    return new Player(this.attrs);
+    return new Player(this._context, this.attrs);
   }
 
   rank() {

--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -5,11 +5,10 @@ import Demo from "./demo";
 import Zone from "./zone";
 import Server from "./server";
 import Split from "./split";
-import { recordsById, wrsByMapId, wrsByMapName } from "../tempus";
 
 class Record extends BaseModel {
   fetchRecord() {
-    return recordsById.load(this.attrs.id);
+    return this._context.tempus.recordsById.load(this.attrs.id);
   }
 
   id() {
@@ -17,9 +16,13 @@ class Record extends BaseModel {
   }
 
   player() {
-    if (this.attrs.player_info) return new Player(this.attrs.player_info);
+    if (this.attrs.player_info)
+      return new Player(this._context, this.attrs.player_info);
 
-    return this.access("player", (r) => new Player(r.player_info));
+    return this.access(
+      "player",
+      (r) => new Player(this._context, r.player_info)
+    );
   }
 
   duration() {
@@ -39,9 +42,9 @@ class Record extends BaseModel {
   }
 
   map() {
-    if (this.attrs.map_info) return new Map(this.attrs.map_info);
+    if (this.attrs.map_info) return new Map(this._context, this.attrs.map_info);
 
-    return this.access("map", (r) => new Map(r.map_info));
+    return this.access("map", (r) => new Map(this._context, r.map_info));
   }
 
   class() {
@@ -53,15 +56,23 @@ class Record extends BaseModel {
   }
 
   demo() {
-    if (this.attrs.demo_info) return new Demo(this.attrs.demo_info);
+    if (this.attrs.demo_info)
+      return new Demo(this._context, this.attrs.demo_info);
 
-    return this.access("demo", (r) => r.demo_info && new Demo(r.demo_info));
+    return this.access(
+      "demo",
+      (r) => r.demo_info && new Demo(this._context, r.demo_info)
+    );
   }
 
   zone() {
-    if (this.attrs.zone_info) return new Zone(this.attrs.zone_info);
+    if (this.attrs.zone_info)
+      return new Zone(this._context, this.attrs.zone_info);
 
-    return this.access("zone", (r) => r.zone_info && new Zone(r.zone_info));
+    return this.access(
+      "zone",
+      (r) => r.zone_info && new Zone(this._context, r.zone_info)
+    );
   }
 
   demoStartTick() {
@@ -75,7 +86,7 @@ class Record extends BaseModel {
   server() {
     return this.access(
       "server",
-      (r) => new Server({ id: r.record_info.server_id })
+      (r) => new Server(this._context, { id: r.record_info.server_id })
     );
   }
 
@@ -87,11 +98,11 @@ class Record extends BaseModel {
     if (!splits) {
       let rs = null;
       if (this.attrs.map_info.name || this.attrs.map.attrs.name) {
-        rs = await wrsByMapName.load(
+        rs = await this._context.tempus.wrsByMapName.load(
           this.attrs.map_info.name || this.attrs.map.attrs.name
         );
       } else {
-        rs = await wrsByMapId.load(
+        rs = await this._context.tempus.wrsByMapId.load(
           this.attrs.map_info.id || this.attrs.map.attrs.id
         );
       }
@@ -108,7 +119,7 @@ class Record extends BaseModel {
       });
     }
 
-    return splits.map((split) => new Split(split));
+    return splits.map((split) => new Split(this._context, split));
   }
 }
 

--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -8,7 +8,7 @@ import Split from "./split";
 
 class Record extends BaseModel {
   fetchRecord() {
-    return this._context.tempus.recordsById.load(this.attrs.id);
+    return this.context.tempus.recordsById.load(this.attrs.id);
   }
 
   id() {
@@ -17,11 +17,11 @@ class Record extends BaseModel {
 
   player() {
     if (this.attrs.player_info)
-      return new Player(this._context, this.attrs.player_info);
+      return new Player(this.context, this.attrs.player_info);
 
     return this.access(
       "player",
-      (r) => new Player(this._context, r.player_info)
+      (r) => new Player(this.context, r.player_info)
     );
   }
 
@@ -42,9 +42,9 @@ class Record extends BaseModel {
   }
 
   map() {
-    if (this.attrs.map_info) return new Map(this._context, this.attrs.map_info);
+    if (this.attrs.map_info) return new Map(this.context, this.attrs.map_info);
 
-    return this.access("map", (r) => new Map(this._context, r.map_info));
+    return this.access("map", (r) => new Map(this.context, r.map_info));
   }
 
   class() {
@@ -57,21 +57,21 @@ class Record extends BaseModel {
 
   demo() {
     if (this.attrs.demo_info)
-      return new Demo(this._context, this.attrs.demo_info);
+      return new Demo(this.context, this.attrs.demo_info);
 
     return this.access(
       "demo",
-      (r) => r.demo_info && new Demo(this._context, r.demo_info)
+      (r) => r.demo_info && new Demo(this.context, r.demo_info)
     );
   }
 
   zone() {
     if (this.attrs.zone_info)
-      return new Zone(this._context, this.attrs.zone_info);
+      return new Zone(this.context, this.attrs.zone_info);
 
     return this.access(
       "zone",
-      (r) => r.zone_info && new Zone(this._context, r.zone_info)
+      (r) => r.zone_info && new Zone(this.context, r.zone_info)
     );
   }
 
@@ -86,7 +86,7 @@ class Record extends BaseModel {
   server() {
     return this.access(
       "server",
-      (r) => new Server(this._context, { id: r.record_info.server_id })
+      (r) => new Server(this.context, { id: r.record_info.server_id })
     );
   }
 
@@ -98,11 +98,11 @@ class Record extends BaseModel {
     if (!splits) {
       let rs = null;
       if (this.attrs.map_info.name || this.attrs.map.attrs.name) {
-        rs = await this._context.tempus.wrsByMapName.load(
+        rs = await this.context.tempus.wrsByMapName.load(
           this.attrs.map_info.name || this.attrs.map.attrs.name
         );
       } else {
-        rs = await this._context.tempus.wrsByMapId.load(
+        rs = await this.context.tempus.wrsByMapId.load(
           this.attrs.map_info.id || this.attrs.map.attrs.id
         );
       }
@@ -119,7 +119,7 @@ class Record extends BaseModel {
       });
     }
 
-    return splits.map((split) => new Split(this._context, split));
+    return splits.map((split) => new Split(this.context, split));
   }
 }
 

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -1,12 +1,11 @@
 import BaseModel from "./base_model";
-import { serversById, serverDemosById } from "../tempus";
 import Player from "./player";
 import Map from "./map";
 import Demo from "./demo";
 
 class Server extends BaseModel {
   fetchRecord() {
-    return serversById.load(this.attrs.id);
+    return this._context.tempus.serversById.load(this.attrs.id);
   }
 
   id() {
@@ -16,7 +15,7 @@ class Server extends BaseModel {
   currentMap() {
     return this.access(
       null,
-      (r) => r.currentMap && new Map({ name: r.currentMap })
+      (r) => r.currentMap && new Map(this._context, { name: r.currentMap })
     );
   }
 
@@ -37,7 +36,10 @@ class Server extends BaseModel {
   }
 
   nextMap() {
-    return this.access(null, (r) => r.nextMap && new Map({ name: r.nextMap }));
+    return this.access(
+      null,
+      (r) => r.nextMap && new Map(this._context, { name: r.nextMap })
+    );
   }
 
   playerCount() {
@@ -47,7 +49,7 @@ class Server extends BaseModel {
   players() {
     return this.access(
       null,
-      (r) => r.users && r.users.map((u) => new Player(u))
+      (r) => r.users && r.users.map((u) => new Player(this._context, u))
     );
   }
 
@@ -80,8 +82,10 @@ class Server extends BaseModel {
   }
 
   async demos() {
-    const demos = await serverDemosById.load(this.attrs.id);
-    return demos.map((demo) => new Demo(demo));
+    const demos = await this._context.tempus.serverDemosById.load(
+      this.attrs.id
+    );
+    return demos.map((demo) => new Demo(this._context, demo));
   }
 }
 

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -5,7 +5,7 @@ import Demo from "./demo";
 
 class Server extends BaseModel {
   fetchRecord() {
-    return this._context.tempus.serversById.load(this.attrs.id);
+    return this.context.tempus.serversById.load(this.attrs.id);
   }
 
   id() {
@@ -15,7 +15,7 @@ class Server extends BaseModel {
   currentMap() {
     return this.access(
       null,
-      (r) => r.currentMap && new Map(this._context, { name: r.currentMap })
+      (r) => r.currentMap && new Map(this.context, { name: r.currentMap })
     );
   }
 
@@ -38,7 +38,7 @@ class Server extends BaseModel {
   nextMap() {
     return this.access(
       null,
-      (r) => r.nextMap && new Map(this._context, { name: r.nextMap })
+      (r) => r.nextMap && new Map(this.context, { name: r.nextMap })
     );
   }
 
@@ -49,7 +49,7 @@ class Server extends BaseModel {
   players() {
     return this.access(
       null,
-      (r) => r.users && r.users.map((u) => new Player(this._context, u))
+      (r) => r.users && r.users.map((u) => new Player(this.context, u))
     );
   }
 
@@ -82,10 +82,8 @@ class Server extends BaseModel {
   }
 
   async demos() {
-    const demos = await this._context.tempus.serverDemosById.load(
-      this.attrs.id
-    );
-    return demos.map((demo) => new Demo(this._context, demo));
+    const demos = await this.context.tempus.serverDemosById.load(this.attrs.id);
+    return demos.map((demo) => new Demo(this.context, demo));
   }
 }
 

--- a/lib/models/zone.js
+++ b/lib/models/zone.js
@@ -8,10 +8,10 @@ class Zone extends BaseModel {
 
   map() {
     if (this.attrs.map_name) {
-      return new Map(this._context, { name: this.attrs.map_name });
+      return new Map(this.context, { name: this.attrs.map_name });
     }
 
-    return new Map(this._context, { id: this.attrs.map_id });
+    return new Map(this.context, { id: this.attrs.map_id });
   }
 
   type() {

--- a/lib/models/zone.js
+++ b/lib/models/zone.js
@@ -8,10 +8,10 @@ class Zone extends BaseModel {
 
   map() {
     if (this.attrs.map_name) {
-      return new Map({ name: this.attrs.map_name });
+      return new Map(this._context, { name: this.attrs.map_name });
     }
 
-    return new Map({ id: this.attrs.map_id });
+    return new Map(this._context, { id: this.attrs.map_id });
   }
 
   type() {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -7,7 +7,7 @@ import {
   GraphQLNonNull,
   GraphQLSchema,
 } from "graphql";
-import { allMaps, allServers, rankingsByType, playerSearch } from "./tempus";
+import { newCachedTempusFetcher } from "./tempus";
 import MapType from "./types/map";
 import Map from "./models/map";
 import PlayerType from "./types/player";
@@ -23,6 +23,7 @@ import Activity from "./models/activity";
 import RankingTypeEnum from "./types/ranking_type_enum";
 import RankingType from "./types/ranking";
 import Ranking from "./models/ranking";
+import fetchResponseByURL from "./utils/fetch_response_by_url";
 
 const RankingListingType = new GraphQLObjectType({
   name: "RankingListing",
@@ -37,115 +38,125 @@ const RankingListingType = new GraphQLObjectType({
   }),
 });
 
-const QueryType = new GraphQLObjectType({
-  name: "Query",
+const newTempusSchema = function (tempus) {
+  const context = { tempus };
 
-  fields: () => ({
-    map: {
-      type: MapType,
-      args: {
-        name: { type: GraphQLString },
-        id: { type: GraphQLInt },
-      },
-      resolve: (root, args) => new Map(args),
-    },
-    maps: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(MapType))),
-      args: {
-        search: { type: GraphQLString },
-        start: { type: GraphQLInt },
-        limit: { type: GraphQLInt },
-      },
-      async resolve(root, args) {
-        let maps = await allMaps.load();
-        if (args.search)
-          maps = maps.filter((map) => map.name.includes(args.search));
-        if (args.start) maps = maps.slice(args.start - 1);
-        if (args.limit) maps = maps.slice(0, args.limit);
-        return maps.map((m) => new Map(m));
-      },
-    },
-    player: {
-      type: PlayerType,
-      args: {
-        id: { type: new GraphQLNonNull(GraphQLInt) },
-      },
-      resolve: (root, args) => new Player(args),
-    },
-    record: {
-      type: RecordType,
-      args: {
-        id: { type: new GraphQLNonNull(GraphQLInt) },
-      },
-      resolve: (root, args) => new Record(args),
-    },
-    demo: {
-      type: DemoType,
-      args: {
-        id: { type: new GraphQLNonNull(GraphQLInt) },
-      },
-      resolve: (root, args) => new Demo(args),
-    },
-    server: {
-      type: ServerType,
-      args: {
-        id: { type: new GraphQLNonNull(GraphQLInt) },
-      },
-      resolve: (root, args) => new Server(args),
-    },
-    servers: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ServerType))),
-      args: {
-        search: { type: GraphQLString },
-        start: { type: GraphQLInt },
-        limit: { type: GraphQLInt },
-      },
-      async resolve(root, args) {
-        let servers = await allServers.load();
-        if (args.search)
-          servers = servers.filter((server) =>
-            server.name.includes(args.search)
-          );
-        if (args.start) servers = servers.slice(args.start - 1);
-        if (args.limit) servers = servers.slice(0, args.limit);
-        return servers.map((s) => new Server(s));
-      },
-    },
-    activity: {
-      type: new GraphQLNonNull(ActivityType),
-      resolve: () => new Activity(),
-    },
-    players: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(PlayerType))),
-      args: {
-        search: { type: GraphQLString },
-        start: { type: GraphQLInt },
-        limit: { type: GraphQLInt },
-      },
-      async resolve(root, args) {
-        let players = await playerSearch.load(args.search);
-        if (args.start) players = players.slice(args.start - 1);
-        if (args.limit) players = players.slice(0, args.limit);
-        return players.map((m) => new Player(m));
-      },
-    },
-    rankings: {
-      type: new GraphQLNonNull(RankingListingType),
-      args: {
-        start: { type: GraphQLInt },
-        type: { type: new GraphQLNonNull(RankingTypeEnum) },
-      },
-      async resolve(root, args) {
-        const rankings = await rankingsByType.load(args);
-        return {
-          count: rankings.count,
-          entries: rankings.players.map((s) => new Ranking(s)),
-        };
-      },
-    },
-  }),
-});
+  const QueryType = new GraphQLObjectType({
+    name: "Query",
 
-const schema = new GraphQLSchema({ query: QueryType });
+    fields: () => ({
+      map: {
+        type: MapType,
+        args: {
+          name: { type: GraphQLString },
+          id: { type: GraphQLInt },
+        },
+        resolve: (root, args) => new Map(context, args),
+      },
+      maps: {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(MapType))),
+        args: {
+          search: { type: GraphQLString },
+          start: { type: GraphQLInt },
+          limit: { type: GraphQLInt },
+        },
+        async resolve(root, args) {
+          let maps = await context.tempus.allMaps.load();
+          if (args.search)
+            maps = maps.filter((map) => map.name.includes(args.search));
+          if (args.start) maps = maps.slice(args.start - 1);
+          if (args.limit) maps = maps.slice(0, args.limit);
+          return maps.map((m) => new Map(context, m));
+        },
+      },
+      player: {
+        type: PlayerType,
+        args: {
+          id: { type: new GraphQLNonNull(GraphQLInt) },
+        },
+        resolve: (root, args) => new Player(context, args),
+      },
+      record: {
+        type: RecordType,
+        args: {
+          id: { type: new GraphQLNonNull(GraphQLInt) },
+        },
+        resolve: (root, args) => new Record(context, args),
+      },
+      demo: {
+        type: DemoType,
+        args: {
+          id: { type: new GraphQLNonNull(GraphQLInt) },
+        },
+        resolve: (root, args) => new Demo(context, args),
+      },
+      server: {
+        type: ServerType,
+        args: {
+          id: { type: new GraphQLNonNull(GraphQLInt) },
+        },
+        resolve: (root, args) => new Server(context, args),
+      },
+      servers: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ServerType))
+        ),
+        args: {
+          search: { type: GraphQLString },
+          start: { type: GraphQLInt },
+          limit: { type: GraphQLInt },
+        },
+        async resolve(root, args) {
+          let servers = await context.tempus.allServers.load();
+          if (args.search)
+            servers = servers.filter((server) =>
+              server.name.includes(args.search)
+            );
+          if (args.start) servers = servers.slice(args.start - 1);
+          if (args.limit) servers = servers.slice(0, args.limit);
+          return servers.map((s) => new Server(context, s));
+        },
+      },
+      activity: {
+        type: new GraphQLNonNull(ActivityType),
+        resolve: () => new Activity(context),
+      },
+      players: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(PlayerType))
+        ),
+        args: {
+          search: { type: GraphQLString },
+          start: { type: GraphQLInt },
+          limit: { type: GraphQLInt },
+        },
+        async resolve(root, args) {
+          let players = await context.tempus.playerSearch.load(args.search);
+          if (args.start) players = players.slice(args.start - 1);
+          if (args.limit) players = players.slice(0, args.limit);
+          return players.map((m) => new Player(context, m));
+        },
+      },
+      rankings: {
+        type: new GraphQLNonNull(RankingListingType),
+        args: {
+          start: { type: GraphQLInt },
+          type: { type: new GraphQLNonNull(RankingTypeEnum) },
+        },
+        async resolve(root, args) {
+          const rankings = await context.tempus.rankingsByType.load(args);
+          return {
+            count: rankings.count,
+            entries: rankings.players.map((s) => new Ranking(context, s)),
+          };
+        },
+      },
+    }),
+  });
 
-export { schema };
+  return new GraphQLSchema({ query: QueryType });
+};
+
+const schema = newTempusSchema(newCachedTempusFetcher(fetchResponseByURL));
+
+export { schema, newTempusSchema };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -38,7 +38,7 @@ const RankingListingType = new GraphQLObjectType({
   }),
 });
 
-const newTempusSchema = function (tempus) {
+function newTempusSchema(tempus) {
   const context = { tempus };
 
   const QueryType = new GraphQLObjectType({
@@ -155,7 +155,7 @@ const newTempusSchema = function (tempus) {
   });
 
   return new GraphQLSchema({ query: QueryType });
-};
+}
 
 const schema = newTempusSchema(newCachedTempusFetcher(fetchResponseByURL));
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -159,4 +159,4 @@ function newTempusSchema(tempus) {
 
 const schema = newTempusSchema(newCachedTempusFetcher(fetchResponseByURL));
 
-export { schema, newTempusSchema };
+export { schema, newTempusSchema, newCachedTempusFetcher };

--- a/lib/tempus.js
+++ b/lib/tempus.js
@@ -1,117 +1,122 @@
-import fetchResponseByURL from "./utils/fetch_response_by_url";
 import CachedByKeyResource from "./utils/cached_by_key_resource";
 import CachedResource from "./utils/cached_resource";
 
-const allMaps = new CachedResource(
-  () => fetchResponseByURL("maps/detailedList"),
-  { timeout: 600 }
-);
-const activity = new CachedResource(() => fetchResponseByURL("activity"));
-const allServers = new CachedResource(async () => {
-  const r = await fetchResponseByURL("servers/statusList");
-  return r.map((server) => ({ ...server.server_info, ...server.game_info }));
-});
-const mapsByName = new CachedByKeyResource(async (name) => {
-  const r = await fetchResponseByURL(`maps/name/${name}/fullOverview2`);
-  /* eslint-disable no-use-before-define */
-  mapsById.set(r.map_info.id, r);
-  /* eslint-enable no-use-before-define */
-  return r;
-});
-const mapsById = new CachedByKeyResource(async (id) => {
-  const r = await fetchResponseByURL(`maps/id/${id}/fullOverview2`);
-  mapsByName.set(r.map_info.name, r);
-  return r;
-});
-const playersById = new CachedByKeyResource((id) =>
-  fetchResponseByURL(`players/id/${id}/stats`)
-);
-const playerSearch = new CachedByKeyResource(async (search) => {
-  return (await fetchResponseByURL(`search/playersAndMaps/${search}`)).players;
-});
-const recordListByMapName = new CachedByKeyResource((info) =>
-  fetchResponseByURL(
-    `maps/name/${info.mapName}/zones/typeindex/${info.zoneType || "map"}/${
-      info.zoneId || 1
-    }/records/list?start=${info.start || 1}&limit=${info.limit || 25}`
-  )
-);
-const recordListByMapId = new CachedByKeyResource((info) =>
-  fetchResponseByURL(
-    `maps/id/${info.mapId}/zones/typeindex/${info.zoneType || "map"}/${
-      info.zoneId || 1
-    }/records/list?start=${info.start || 1}&limit=${info.limit || 25}`
-  )
-);
-const playerRecordByMapName = new CachedByKeyResource((info) => {
-  const c = info.class === "soldier" ? 3 : 4;
-  return fetchResponseByURL(
-    `maps/name/${info.mapName}/zones/typeindex/${info.zoneType || "map"}/${
-      info.zoneId || 1
-    }/records/player/${info.playerId}/${c}`
+const newCachedTempusFetcher = function (fetchResponseByURL) {
+  let fetcher = {};
+  fetcher.allMaps = new CachedResource(
+    () => fetchResponseByURL("maps/detailedList"),
+    { timeout: 600 }
   );
-});
-const playerRecordByMapId = new CachedByKeyResource((info) => {
-  const c = info.class === "soldier" ? 3 : 4;
-  return fetchResponseByURL(
-    `maps/id/${info.mapId}/zones/typeindex/${info.zoneType || "map"}/${
-      info.zoneId || 1
-    }/records/player/${info.playerId}/${c}`
+  fetcher.activity = new CachedResource(() => fetchResponseByURL("activity"));
+  fetcher.allServers = new CachedResource(async () => {
+    const r = await fetchResponseByURL("servers/statusList");
+    return r.map((server) => ({ ...server.server_info, ...server.game_info }));
+  });
+  fetcher.mapsByName = new CachedByKeyResource(async (name) => {
+    const r = await fetchResponseByURL(`maps/name/${name}/fullOverview2`);
+    /* eslint-disable no-use-before-define */
+    fetcher.mapsById.set(r.map_info.id, r);
+    /* eslint-enable no-use-before-define */
+    return r;
+  });
+  fetcher.mapsById = new CachedByKeyResource(async (id) => {
+    const r = await fetchResponseByURL(`maps/id/${id}/fullOverview2`);
+    fetcher.mapsByName.set(r.map_info.name, r);
+    return r;
+  });
+  fetcher.playersById = new CachedByKeyResource((id) =>
+    fetchResponseByURL(`players/id/${id}/stats`)
   );
-});
-const recordsById = new CachedByKeyResource(
-  (id) => fetchResponseByURL(`records/id/${id}/overview`),
-  { timeout: 120 }
-);
-const demosById = new CachedByKeyResource(
-  (id) => fetchResponseByURL(`demos/id/${id}/overview`),
-  { timeout: 120 }
-);
-const serverDemosById = new CachedByKeyResource(
-  (id) => fetchResponseByURL(`servers/${id}/demos`),
-  { timeout: 120 }
-);
-const rankingsByType = new CachedByKeyResource((info) => {
-  if (info.type === "soldier") {
-    return fetchResponseByURL(`ranks/class/3?start=${info.start || 1}`);
-  }
-  if (info.type === "demoman") {
-    return fetchResponseByURL(`ranks/class/4?start=${info.start || 1}`);
-  }
-  return fetchResponseByURL(`ranks/overall?start=${info.start || 1}`);
-});
-const serversById = {
-  load: async (id) => {
-    const servers = await allServers.load();
-    return servers.find((s) => s.id === id);
-  },
-};
-const wrsByMapName = new CachedByKeyResource(
-  (name) => fetchResponseByURL(`maps/name/${name}/wrs`),
-  { timeout: 120 }
-);
-const wrsByMapId = new CachedByKeyResource(
-  (id) => fetchResponseByURL(`maps/id/${id}/wrs`),
-  { timeout: 120 }
-);
+  fetcher.playerSearch = new CachedByKeyResource(async (search) => {
+    return (await fetchResponseByURL(`search/playersAndMaps/${search}`))
+      .players;
+  });
+  fetcher.recordListByMapName = new CachedByKeyResource((info) =>
+    fetchResponseByURL(
+      `maps/name/${info.mapName}/zones/typeindex/${info.zoneType || "map"}/${
+        info.zoneId || 1
+      }/records/list?start=${info.start || 1}&limit=${info.limit || 25}`
+    )
+  );
+  fetcher.recordListByMapId = new CachedByKeyResource((info) =>
+    fetchResponseByURL(
+      `maps/id/${info.mapId}/zones/typeindex/${info.zoneType || "map"}/${
+        info.zoneId || 1
+      }/records/list?start=${info.start || 1}&limit=${info.limit || 25}`
+    )
+  );
+  fetcher.playerRecordByMapName = new CachedByKeyResource((info) => {
+    const c = info.class === "soldier" ? 3 : 4;
+    return fetchResponseByURL(
+      `maps/name/${info.mapName}/zones/typeindex/${info.zoneType || "map"}/${
+        info.zoneId || 1
+      }/records/player/${info.playerId}/${c}`
+    );
+  });
+  fetcher.playerRecordByMapId = new CachedByKeyResource((info) => {
+    const c = info.class === "soldier" ? 3 : 4;
+    return fetchResponseByURL(
+      `maps/id/${info.mapId}/zones/typeindex/${info.zoneType || "map"}/${
+        info.zoneId || 1
+      }/records/player/${info.playerId}/${c}`
+    );
+  });
+  fetcher.recordsById = new CachedByKeyResource(
+    (id) => fetchResponseByURL(`records/id/${id}/overview`),
+    { timeout: 120 }
+  );
+  fetcher.demosById = new CachedByKeyResource(
+    (id) => fetchResponseByURL(`demos/id/${id}/overview`),
+    { timeout: 120 }
+  );
+  fetcher.serverDemosById = new CachedByKeyResource(
+    (id) => fetchResponseByURL(`servers/${id}/demos`),
+    { timeout: 120 }
+  );
+  fetcher.rankingsByType = new CachedByKeyResource((info) => {
+    if (info.type === "soldier") {
+      return fetchResponseByURL(`ranks/class/3?start=${info.start || 1}`);
+    }
+    if (info.type === "demoman") {
+      return fetchResponseByURL(`ranks/class/4?start=${info.start || 1}`);
+    }
+    return fetchResponseByURL(`ranks/overall?start=${info.start || 1}`);
+  });
+  fetcher.serversById = {
+    load: async (id) => {
+      const servers = await fetcher.allServers.load();
+      return servers.find((s) => s.id === id);
+    },
+  };
+  fetcher.wrsByMapName = new CachedByKeyResource(
+    (name) => fetchResponseByURL(`maps/name/${name}/wrs`),
+    { timeout: 120 }
+  );
+  fetcher.wrsByMapId = new CachedByKeyResource(
+    (id) => fetchResponseByURL(`maps/id/${id}/wrs`),
+    { timeout: 120 }
+  );
 
-export {
-  mapsById,
-  mapsByName,
-  playersById,
-  playerSearch,
-  recordListByMapName,
-  recordListByMapId,
-  playerRecordByMapName,
-  playerRecordByMapId,
-  recordsById,
-  demosById,
-  serverDemosById,
-  serversById,
-  allServers,
-  allMaps,
-  activity,
-  rankingsByType,
-  wrsByMapName,
-  wrsByMapId,
+  fetcher.clearCache = function () {
+    fetcher.allMaps.clearCache();
+    fetcher.activity.clearCache();
+    fetcher.allServers.clearCache();
+    fetcher.mapsByName.clearCache();
+    fetcher.mapsById.clearCache();
+    fetcher.playersById.clearCache();
+    fetcher.playerSearch.clearCache();
+    fetcher.recordListByMapName.clearCache();
+    fetcher.recordListByMapId.clearCache();
+    fetcher.playerRecordByMapName.clearCache();
+    fetcher.playerRecordByMapId.clearCache();
+    fetcher.recordsById.clearCache();
+    fetcher.demosById.clearCache();
+    fetcher.serverDemosById.clearCache();
+    fetcher.rankingsByType.clearCache();
+    fetcher.wrsByMapName.clearCache();
+    fetcher.wrsByMapId.clearCache();
+  };
+  return fetcher;
 };
+
+export { newCachedTempusFetcher };

--- a/lib/tempus.js
+++ b/lib/tempus.js
@@ -1,8 +1,8 @@
 import CachedByKeyResource from "./utils/cached_by_key_resource";
 import CachedResource from "./utils/cached_resource";
 
-const newCachedTempusFetcher = function (fetchResponseByURL) {
-  let fetcher = {};
+function newCachedTempusFetcher(fetchResponseByURL) {
+  const fetcher = {};
   fetcher.allMaps = new CachedResource(
     () => fetchResponseByURL("maps/detailedList"),
     { timeout: 600 }
@@ -97,7 +97,7 @@ const newCachedTempusFetcher = function (fetchResponseByURL) {
     { timeout: 120 }
   );
 
-  fetcher.clearCache = function () {
+  fetcher.clearCache = function clearCache() {
     fetcher.allMaps.clearCache();
     fetcher.activity.clearCache();
     fetcher.allServers.clearCache();
@@ -117,6 +117,6 @@ const newCachedTempusFetcher = function (fetchResponseByURL) {
     fetcher.wrsByMapId.clearCache();
   };
   return fetcher;
-};
+}
 
 export { newCachedTempusFetcher };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "tempus-api-graphql",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempus-api-graphql",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -5321,9 +5321,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
@@ -15678,9 +15678,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempus-api-graphql",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "A GraphQL wrapper for the tempus.xyz api",
   "main": "dist/schema.js",
   "scripts": {


### PR DESCRIPTION
It can be hard to work with the dependencies as they were to add any sort of customization (see #9). By injecting dependencies and passing them through built models we can allow consumers to generate schemas with configurable caching, alternative fetch mechanisms, etc.

Main use cases here are to increase configuration and to make axios an optional dependency