### PR TITLE
Fix type issue with nil demos being treated as real

### DIFF
--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -118,6 +118,18 @@ class Map extends BaseModel {
     }
     if (!r.result) return null;
 
+    let demo_info = null;
+    if (r.result.demo_id) {
+      demo_info = {
+        id: r.result.demo_id,
+        url: r.result.demo_url,
+        server_info: {
+          id: r.result.demo_server_id,
+          name: r.result.demo_server_name,
+        },
+      };
+    }
+
     return new Record(this.context, {
       ...r.result,
       zone_info: r.zone_info,
@@ -127,14 +139,7 @@ class Map extends BaseModel {
         steamid: r.result.steamid,
       },
       map: this,
-      demo_info: {
-        id: r.result.demo_id,
-        url: r.result.demo_url,
-        server_info: {
-          id: r.result.demo_server_id,
-          name: r.result.demo_server_name,
-        },
-      },
+      demo_info: demo_info,
     });
   }
 

--- a/lib/models/map.js
+++ b/lib/models/map.js
@@ -118,9 +118,9 @@ class Map extends BaseModel {
     }
     if (!r.result) return null;
 
-    let demo_info = null;
+    let demoInfo = null;
     if (r.result.demo_id) {
-      demo_info = {
+      demoInfo = {
         id: r.result.demo_id,
         url: r.result.demo_url,
         server_info: {
@@ -139,7 +139,7 @@ class Map extends BaseModel {
         steamid: r.result.steamid,
       },
       map: this,
-      demo_info: demo_info,
+      demo_info: demoInfo,
     });
   }
 

--- a/lib/models/player.js
+++ b/lib/models/player.js
@@ -94,6 +94,18 @@ class Player extends BaseModel {
     }
     if (!r.result) return null;
 
+    let demo_info = null;
+    if (r.result.demo_id) {
+      demo_info = {
+        id: r.result.demo_id,
+        url: r.result.demo_url,
+        server_info: {
+          id: r.result.demo_server_id,
+          name: r.result.demo_server_name,
+        },
+      };
+    }
+
     return new Record(this.context, {
       ...r.result,
       zone_info: r.zone_info,
@@ -103,14 +115,7 @@ class Player extends BaseModel {
         steamid: r.result.steamid,
       },
       map: new Map(this.context, { id: r.zone_info.map_id }),
-      demo_info: {
-        id: r.result.demo_id,
-        url: r.result.demo_url,
-        server_info: {
-          id: r.result.demo_server_id,
-          name: r.result.demo_server_name,
-        },
-      },
+      demo_info: demo_info,
     });
   }
 }

--- a/lib/models/player.js
+++ b/lib/models/player.js
@@ -94,9 +94,9 @@ class Player extends BaseModel {
     }
     if (!r.result) return null;
 
-    let demo_info = null;
+    let demoInfo = null;
     if (r.result.demo_id) {
-      demo_info = {
+      demoInfo = {
         id: r.result.demo_id,
         url: r.result.demo_url,
         server_info: {
@@ -115,7 +115,7 @@ class Player extends BaseModel {
         steamid: r.result.steamid,
       },
       map: new Map(this.context, { id: r.zone_info.map_id }),
-      demo_info: demo_info,
+      demo_info: demoInfo,
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tempus-api-graphql",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tempus-api-graphql",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempus-api-graphql",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A GraphQL wrapper for the tempus.xyz api",
   "main": "dist/schema.js",
   "scripts": {


### PR DESCRIPTION
To reduce unnecessary network requests, we store all of the demo info we get from record requests. In the cases in this pr, we skipped a null check for demo id, resulting in a type error downstream if we try to access that id.